### PR TITLE
Include .Api in Migrations build

### DIFF
--- a/server/Dockerfile.migrate
+++ b/server/Dockerfile.migrate
@@ -3,14 +3,17 @@ FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 
 WORKDIR /app
 
-COPY OurCity.MigrationsRunner/*.csproj .
-RUN dotnet restore
+COPY OurCity.MigrationsRunner/*.csproj ./OurCity.MigrationsRunner/
+COPY OurCity.Api/*.csproj ./OurCity.Api/
 
-COPY . .
+RUN dotnet restore ./OurCity.MigrationsRunner/OurCity.MigrationsRunner.csproj
+RUN dotnet restore ./OurCity.Api/OurCity.Api.csproj
 
-WORKDIR /app/OurCity.MigrationsRunner
+COPY OurCity.MigrationsRunner ./OurCity.MigrationsRunner/
+COPY OurCity.Api ./OurCity.Api/
 
-RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false
+RUN dotnet publish OurCity.MigrationsRunner/OurCity.MigrationsRunner.csproj -c Release -o /app/publish /p:UseAppHost=false
+RUN dotnet publish OurCity.Api/OurCity.Api.csproj -c Release -o /app/publish /p:UseAppHost=false
 
 #runtime stage
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime


### PR DESCRIPTION
# Description

- Brief overview of the motivation for this work 
  - Migrations were not working on my Mac, but were on Windows
- Brief overview of how you completed this work
  - Added *.Api stuff to Dockerfile.migrate
- Include the issue number: #28 

# Checklist

- [x] I have added/updated tests
- [x] All CI checks pass
- [x] (Leave for right before merging) Ensure migration date is the most recent
