### PR TITLE
Pictures can be reordered when creating post

### DIFF
--- a/webapp/src/views/CreatePostView.vue
+++ b/webapp/src/views/CreatePostView.vue
@@ -106,20 +106,6 @@ const onDrop = (event: DragEvent, targetIndex: number) => {
   dragIndex.value = null;
 };
 
-const moveImageLeft = (index: number) => {
-  if (index <= 0) return;
-  const files = formData.value.images;
-  const [item] = files.splice(index, 1);
-  files.splice(index - 1, 0, item);
-};
-
-const moveImageRight = (index: number) => {
-  const files = formData.value.images;
-  if (index >= files.length - 1) return;
-  const [item] = files.splice(index, 1);
-  files.splice(index + 1, 0, item);
-};
-
 // Computed properties for showing errors only after touch
 const showTitleError = computed(() => {
   return titleTouched.value && errors.value.title;


### PR DESCRIPTION
# Description

- Brief overview of the motivation for this work
    - Previously, it was inconvenient for users to add pictures because they had to add them in a specific order, but now you can drag the picture previews on the create post page to reorder the images.
- Include the issue number: N/A

# Checklist

- [ ] I have added/updated tests
- [ ] All CI checks pass
- [ ] (Leave for right before merging) Ensure migration date is the most recent
