### PR TITLE
Rename TagIds to Tags in the backend

### DIFF
--- a/server/OurCity.Api.Test/IntegrationTests/PostIntegrationTests.cs
+++ b/server/OurCity.Api.Test/IntegrationTests/PostIntegrationTests.cs
@@ -341,7 +341,7 @@ public class PostIntegrationTests : IClassFixture<OurCityWebApplicationFactory>,
             Title = "New Post",
             Description = "New Description for test",
             Location = "Test Location",
-            TagIds = new List<Guid> { _testTagId },
+            Tags = new List<Guid> { _testTagId },
         };
 
         var loginRequest = new UserCreateRequestDto

--- a/server/OurCity.Api.Test/UnitTests/Services/PostServiceTests.cs
+++ b/server/OurCity.Api.Test/UnitTests/Services/PostServiceTests.cs
@@ -289,13 +289,13 @@ public class PostServiceTests
             Title = "Test Post",
             Description = "Test Description",
             Location = "Test Location",
-            TagIds = new List<Guid>(),
+            Tags = new List<Guid>(),
         };
 
         var tags = new List<Tag>();
         var createdPost = CreateTestFatPost(Guid.NewGuid(), _testUserId, createDto.Title);
 
-        _mockTagRepository.Setup(r => r.GetTagsByIds(createDto.TagIds)).ReturnsAsync(tags);
+        _mockTagRepository.Setup(r => r.GetTagsByIds(createDto.Tags)).ReturnsAsync(tags);
 
         _mockPostRepository.Setup(r => r.CreatePost(It.IsAny<Post>())).ReturnsAsync(createdPost);
 
@@ -308,7 +308,7 @@ public class PostServiceTests
         Assert.Equal(createDto.Title, result.Data.Title);
         Assert.Equal(createDto.Description, result.Data.Description);
 
-        _mockTagRepository.Verify(r => r.GetTagsByIds(createDto.TagIds), Times.Once);
+        _mockTagRepository.Verify(r => r.GetTagsByIds(createDto.Tags), Times.Once);
         _mockPostRepository.Verify(r => r.CreatePost(It.IsAny<Post>()), Times.Once);
     }
 
@@ -326,12 +326,12 @@ public class PostServiceTests
         {
             Title = "Post with Tags",
             Description = "Description",
-            TagIds = new List<Guid> { tagId },
+            Tags = new List<Guid> { tagId },
         };
 
         Post? capturedPost = null;
 
-        _mockTagRepository.Setup(r => r.GetTagsByIds(createDto.TagIds)).ReturnsAsync(tags);
+        _mockTagRepository.Setup(r => r.GetTagsByIds(createDto.Tags)).ReturnsAsync(tags);
 
         _mockPostRepository
             .Setup(r => r.CreatePost(It.IsAny<Post>()))

--- a/server/OurCity.Api/Common/Dtos/Post/PostCreateRequestDto.cs
+++ b/server/OurCity.Api/Common/Dtos/Post/PostCreateRequestDto.cs
@@ -29,5 +29,5 @@ public class PostCreateRequestDto
 
     public double? Longitude { get; set; }
 
-    public List<Guid> TagIds { get; set; } = new();
+    public List<Guid> Tags { get; set; } = new();
 }

--- a/server/OurCity.Api/Services/PostService.cs
+++ b/server/OurCity.Api/Services/PostService.cs
@@ -87,7 +87,7 @@ public class PostService : IPostService
         PostCreateRequestDto postCreateRequestDto
     )
     {
-        var tags = await _tagRepository.GetTagsByIds(postCreateRequestDto.TagIds);
+        var tags = await _tagRepository.GetTagsByIds(postCreateRequestDto.Tags);
 
         var createdPost = await _postRepository.CreatePost(
             postCreateRequestDto.CreateDtoToEntity(userId, tags.ToList())


### PR DESCRIPTION
# Description

- Brief overview of the motivation for this work
 - Tags were still not being populated correctly in the frontend after creating a post and viewing the post detail.
- Brief overview of how you completed this work
 - Renamed TagIds -> Tags in the PostCreateRequestDto in the backend and all references to it.
- Include the issue number: #141

# Checklist

- [x] I have added/updated tests
- [x] All CI checks pass
- [x] (Leave for right before merging) Ensure migration date is the most recent
