### PR TITLE
Fix null-forgiving operator placement

### DIFF
--- a/server/OurCity.Api/Infrastructure/PostBookmarkRepository.cs
+++ b/server/OurCity.Api/Infrastructure/PostBookmarkRepository.cs
@@ -36,8 +36,8 @@ public class PostBookmarkRepository : IPostBookmarkRepository
     {
         IQueryable<PostBookmark> query = _appDbContext
             .PostBookmarks.Where(b => b.UserId == userId)
-            .Include(b => b.Post!)
-            .ThenInclude(p => p.Author)
+            .Include(b => b.Post)
+            .ThenInclude(p => p!.Author)
             .OrderByDescending(b => b.BookmarkedAt);
 
         if (cursor.HasValue)


### PR DESCRIPTION
# Description

- Brief overview of the motivation for this work
   - Fetching bookmarks was still returning posts with null author name when it shouldn't hae
- Brief overview of how you completed this work
   - Fixed backend post bookmark repository null-forgiving operator placement
- Include the issue number: #166 

# Checklist

- [x] I have added/updated tests
- [x] All CI checks pass
- [x] (Leave for right before merging) Ensure migration date is the most recent
